### PR TITLE
Do not deploy .nojekyll file for previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,6 +45,10 @@ jobs:
             --environment stage \
             --baseURL "${{ steps.url.outputs.URL }}/pr-preview/pr-${{ github.event.number }}"
 
+      - name: Drop .nojekyll for previews
+        if: github.event.action != 'closed' # You might want to skip the build if the PR has been closed
+        run: rm public/.nojekyll
+
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:


### PR DESCRIPTION
This should prevent cluttering of the `gh-pages` branch with unneeded folders over time.