### PR TITLE
Remove compile warning of hugo

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -88,9 +88,6 @@ Params:
     # strava: "userid"
     # lastfm: "username"
 
-module:
-  imports:
-  - path: "github.com/halogenica/beautifulhugo"
 theme: "github.com/halogenica/beautifulhugo"
 
 menu:


### PR DESCRIPTION
The theme module was imported twice and this commit should prevent the (unnecessary) manual loading of the module. The theme is still loaded and present.